### PR TITLE
Add snapshot debugging and persistent memory

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -35,6 +35,11 @@ def build_parser() -> argparse.ArgumentParser:
         default="right",
         help="Wall-following hand for exploration",
     )
+    parser.add_argument(
+        "--snapshot-dir",
+        default=None,
+        help="Directory to save 1 FPS snapshots and perception JSON",
+    )
     return parser
 
 
@@ -51,6 +56,7 @@ def main() -> None:
         langs=args.lang,
         wall_hand=args.wall_hand,
         debug=args.debug,
+        snapshot_dir=args.snapshot_dir,
     )
     runner.run(dry_run=args.dry_run)
 


### PR DESCRIPTION
## Summary
- allow Memory to persist between runs via JSON save/load with compacted visited cells
- add `--snapshot-dir` option to save 1FPS frames and perception JSON
- integrate rotating file logger (10MB, 3 files)

## Testing
- `python -m py_compile rpgm_autoplay/memory/state.py rpgm_autoplay/main_loop.py cli.py`
- `python cli.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6898d2600d00832fa0b1d14014b2b16c